### PR TITLE
Fixed logic in CreateUser when adding roles

### DIFF
--- a/src/apps/PingYourPackage.Domain/Services/MembershipService.cs
+++ b/src/apps/PingYourPackage.Domain/Services/MembershipService.cs
@@ -81,7 +81,7 @@ namespace PingYourPackage.Domain.Services {
             _userRepository.Add(user);
             _userRepository.Save();
 
-            if (roles != null || roles.Length > 0) { 
+            if (roles != null && roles.Length > 0) { 
 
                 foreach (var roleName in roles) {
 


### PR DESCRIPTION
I don't think "roles is not null OR roles.Length is larger than zero" was the intended logic.
